### PR TITLE
allow usage of nodejs version 12.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,7 @@ class Middleware {
     switch (this.serverless.service.provider.runtime) {
       case 'nodejs8.10':
       case 'nodejs10.x':
+      case 'nodejs12.x':
         return Middleware.getNodeExtension(handlers);
       // TODO add other runtimes
       default:


### PR DESCRIPTION
With the recently deprecation of nodejs version 8, as seen in aws announcement https://aws.amazon.com/pt/blogs/compute/node-js-12-x-runtime-now-available-in-aws-lambda/, i began to use version 12.x, in my tests and usage didn't happened any issue or incompatibility.