### PR TITLE
Add `nodejs16.x`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,6 +195,7 @@ class Middleware {
       case 'nodejs10.x':
       case 'nodejs12.x':
       case 'nodejs14.x':
+      case 'nodejs16.x':
         return this.getNodeExtension(handlers);
       // TODO add other runtimes
       default:


### PR DESCRIPTION
Fixes #39.
See:
- [AWS Release Blog](https://aws.amazon.com/about-aws/whats-new/2022/05/aws-lambda-adds-support-node-js-16/)
- [AWS Compute Blog](https://aws.amazon.com/blogs/compute/node-js-16-x-runtime-now-available-in-aws-lambda/)
- [Serverless Offline](https://github.com/dherault/serverless-offline/pull/1396)