### PR TITLE
Add `.js` extension to `require()`

### DIFF
--- a/src/javascript.js
+++ b/src/javascript.js
@@ -23,7 +23,7 @@ function createJSMiddlewareHandler(handlers, pathToRoot) {
     }, {});
 
   const imports = Object.keys(handlersInfo)
-    .map((handler) => `const ${handlersInfo[handler]} = require('${pathToRoot}/${handler}');`).join('\n');
+    .map((handler) => `const ${handlersInfo[handler]} = require('${pathToRoot}/${handler}'.js);`).join('\n');
 
   const promiseChain = handlers.map((handler) => {
     if (handler.then && handler.catch) {


### PR DESCRIPTION
This fixes https://github.com/juanjoDiaz/serverless-middleware/issues/45 by including the `.js` extension in the `require()`.