### PR TITLE
feat: support for nodejs22.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Serverless plugin to allow middleware handlers configured directly in serverless
 - [x] nodejs16.x (both Javascript and Typescript)
 - [x] nodejs18.x (both Javascript and Typescript)
 - [x] nodejs20.x (both Javascript and Typescript)
+- [x] nodejs22.x (both Javascript and Typescript)
 - [ ] dotnetcore2.1
 - [ ] java8
 - [ ] java11
@@ -63,7 +64,7 @@ For example:
 ```yaml
 provider:
   name: aws
-  runtime: nodejs20.x
+  runtime: nodejs22.x
   
 functions:
   myFunction:
@@ -121,7 +122,7 @@ For example:
 
 provider:
   name: aws
-  runtime: nodejs20.x
+  runtime: nodejs22.x
   
 functions:
   myFunction:
@@ -146,7 +147,7 @@ For example:
 
 provider:
   name: aws
-  runtime: nodejs20.x
+  runtime: nodejs22.x
 
 custom:
   middleware:

--- a/src/index.js
+++ b/src/index.js
@@ -197,6 +197,7 @@ class Middleware {
       case 'nodejs16.x':
       case 'nodejs18.x':
       case 'nodejs20.x':
+      case 'nodejs22.x':
         return this.getNodeExtension(handlers);
       // TODO add other runtimes
       default:

--- a/test/utils/configUtils.js
+++ b/test/utils/configUtils.js
@@ -21,7 +21,7 @@ function getServerlessConfig(serverlessOverrides = {}) {
       servicePath: serverless.config.servicePath,
     },
     service: {
-      provider: serverless.service.provider || { stage: '', region: '', runtime: 'nodejs20.x' },
+      provider: serverless.service.provider || { stage: '', region: '', runtime: 'nodejs22.x' },
       defaults: serverless.service.defaults || { stage: '', region: '' },
       service: 'middleware-test',
       custom: serverless.service.custom,


### PR DESCRIPTION
Hello!

Since the 21st of November, AWS supports Node.js version 22 as a runtime: https://aws.amazon.com/es/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/ 

This contribution adds support for that version.