### PR TITLE
feat: add Node.js 24.x runtime support

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest] # macos-latest is too slow
-        node-version: [18.x, 16.x, 14.x]
+        node-version: [24.x, 18.x, 16.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Serverless plugin to allow middleware handlers configured directly in serverless
 - [x] nodejs18.x (both Javascript and Typescript)
 - [x] nodejs20.x (both Javascript and Typescript)
 - [x] nodejs22.x (both Javascript and Typescript)
+- [x] nodejs24.x (both Javascript and Typescript)
 - [ ] dotnetcore2.1
 - [ ] java8
 - [ ] java11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-middleware",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-middleware",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.45.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-middleware",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Serverless plugin to allow middleware handlers configured directly in serverless.yaml",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -198,6 +198,7 @@ class Middleware {
       case 'nodejs18.x':
       case 'nodejs20.x':
       case 'nodejs22.x':
+      case 'nodejs24.x':
         return this.getNodeExtension(handlers);
       // TODO add other runtimes
       default:

--- a/test/processAllFunctionsHooks.node.test.js
+++ b/test/processAllFunctionsHooks.node.test.js
@@ -57,6 +57,26 @@ describe.each([
       expect(fsAsync.writeFile).not.toHaveBeenCalled();
     });
 
+    it('should support nodejs24.x runtime', async () => {
+      const serverless = getServerlessConfig({
+        service: {
+          provider: { stage: '', region: '', runtime: 'nodejs24.x' },
+          functions: {
+            someFunc1: {
+              name: 'someFunc1',
+              middleware: [{ then: 'middleware1.handler' }, 'middleware2.handler', 'someFunc1.handler'],
+            },
+          },
+        },
+      });
+      const pluginUtils = getPluginUtils();
+
+      const plugin = new Middleware(serverless, {}, pluginUtils);
+
+      // Should not throw an error for nodejs24.x
+      await expect(plugin.hooks[hook]()).resolves.not.toThrow();
+    });
+
     it('should error on unsupported node extensions', async () => {
       fs.existsSync.mockImplementation((filePath) => !filePath.startsWith('middleware1'));
       const serverless = getServerlessConfig({

--- a/test/processSingleFunctionHooks.node.test.js
+++ b/test/processSingleFunctionHooks.node.test.js
@@ -54,6 +54,26 @@ describe.each(['before:deploy:function:packageFunction', 'before:invoke:local:in
       expect(fsAsync.writeFile).not.toHaveBeenCalled();
     });
 
+    it('should support nodejs24.x runtime', async () => {
+      const serverless = getServerlessConfig({
+        service: {
+          provider: { stage: '', region: '', runtime: 'nodejs24.x' },
+          functions: {
+            someFunc1: {
+              name: 'someFunc1',
+              middleware: [{ then: 'middleware1.handler' }, 'middleware2.handler', 'someFunc1.handler'],
+            },
+          },
+        },
+      });
+      const pluginUtils = getPluginUtils();
+
+      const plugin = new Middleware(serverless, { function: 'someFunc1' }, pluginUtils);
+
+      // Should not throw an error for nodejs24.x
+      await expect(plugin.hooks[hook]()).resolves.not.toThrow();
+    });
+
     it('should error on unsupported node extensions', async () => {
       fs.existsSync.mockImplementation((filePath) => !filePath.startsWith('middleware1'));
       const serverless = getServerlessConfig({


### PR DESCRIPTION
After upgrading to Serverless Framework v4, I needed to use Node.js 24 for my Lambda functions, but the plugin was throwing an error for unsupported runtime. I patched this locally in my project and thought it would be helpful to contribute this back to the project so others can use Node.js 24 without needing to patch locally.

## Changes

- Added `nodejs24.x` to runtime check in `src/index.js`
- Added Node.js 24.x to CI test matrix (`.github/workflows/on-push.yaml`)
- Updated README.md to document nodejs24.x support
- Added test cases to verify nodejs24.x runtime support in both test files

## Testing

- ✅ All existing tests pass (141 tests)
- ✅ New test cases verify nodejs24.x is supported and doesn't throw errors
- ✅ CI will run tests against Node.js 24.x
- ✅ Tested locally with Node.js 24

## References

- [AWS Lambda adds support for Node.js 24](https://aws.amazon.com/about-aws/whats-new/2025/11/aws-lambda-nodejs-24/)